### PR TITLE
Enhance Configuration for Default Subject Names and All-Streams Handling

### DIFF
--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -16,7 +16,7 @@ func Default() Config {
 			Level: "debug",
 		},
 		NATS: natsclient.Config{
-			AllExistingStreams: true,
+			AllExistingStreams: false,
 			NewStreamAllow:     true,
 			Streams: []natsclient.Stream{{
 				Name:    "test",

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -16,7 +16,8 @@ func Default() Config {
 			Level: "debug",
 		},
 		NATS: natsclient.Config{
-			NewStreamAllow: true,
+			AllExistingStreams: true,
+			NewStreamAllow:     true,
 			Streams: []natsclient.Stream{{
 				Name:    "test",
 				Subject: "test",

--- a/internal/natsclient/config.go
+++ b/internal/natsclient/config.go
@@ -3,6 +3,7 @@ package natsclient
 import "time"
 
 type Config struct {
+	AllExistingStreams     bool          `json:"all_existing_streams" koanf:"all_existing_streams"`
 	NewStreamAllow         bool          `json:"new_stream_allow" koanf:"new_stream_allow"`
 	Streams                []Stream      `json:"stream,omitempty"            koanf:"stream"`
 	URL                    string        `json:"url,omitempty"            koanf:"url"`

--- a/internal/natsclient/jetstream.go
+++ b/internal/natsclient/jetstream.go
@@ -13,7 +13,7 @@ var (
 	successfulSubscribe = "successful subscribe"
 	failedPublish       = "failed publish"
 	successfulPublish   = "successful publish"
-	subject_suffix      = "_blackbox_exporter"
+	subjectSuffix       = "_blackbox_exporter"
 )
 
 type Message struct {
@@ -82,7 +82,7 @@ func (j *Jetstream) UpdateOrCreateStream() {
 	}
 	for i, stream := range j.config.Streams {
 		if stream.Subject == "" {
-			j.config.Streams[i].Subject = stream.Name + subject_suffix
+			j.config.Streams[i].Subject = stream.Name + subjectSuffix
 		}
 
 		info, err := j.jetstream.StreamInfo(stream.Name)

--- a/internal/natsclient/jetstream.go
+++ b/internal/natsclient/jetstream.go
@@ -91,7 +91,7 @@ func (j *Jetstream) UpdateOrCreateStream() {
 		} else if err == nats.ErrStreamNotFound && j.config.NewStreamAllow {
 			j.createStream(j.config.Streams[i])
 		} else {
-			j.logger.Panic("could not add subject", zap.Error(err))
+			j.logger.Error("could not add subject", zap.String("stream", stream.Name), zap.Error(err))
 		}
 	}
 }
@@ -104,7 +104,7 @@ func (j *Jetstream) updateStream(stream Stream, info *nats.StreamInfo) {
 		Subjects: subjects,
 	})
 	if err != nil {
-		j.logger.Panic("could not add subject to existing stream", zap.Error(err))
+		j.logger.Error("could not add subject to existing stream", zap.String("stream", stream.Name), zap.Error(err))
 	}
 	j.logger.Info("stream updated")
 }
@@ -115,12 +115,15 @@ func (j *Jetstream) createStream(stream Stream) {
 		Subjects: []string{stream.Subject},
 	})
 	if err != nil {
-		j.logger.Panic("could not add stream", zap.Error(err))
+		j.logger.Error("could not add stream", zap.String("stream", stream.Name), zap.Error(err))
 	}
 	j.logger.Info("add new stream")
 }
 
 func (j *Jetstream) StartBlackboxTest() {
+	if j.config.Streams == nil {
+		j.logger.Panic("at least one stream is required.")
+	}
 	for _, stream := range j.config.Streams {
 		messageChannel := j.createSubscribe(stream.Subject)
 		go j.jetstreamPublish(stream.Subject, stream.Name)


### PR DESCRIPTION
This merge request introduces two key enhancements to the configuration:

1. **Default Subject Name Handling**:
   - If no subject name is provided in the configuration, the system will now use a default value.
   - The default value is derived by appending "_blackbox_exporter" to the stream name.

2. **Publish and Consume from All Existing Streams**:
   - A new configuration option `all_existing_streams` is introduced.
   - Setting `all_existing_streams` to `true` enables publishing and consuming from all existing streams.